### PR TITLE
fix: flashing problem of ReRenderPage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import Header from '../components/Header';
 import Head from 'next/head';
 import Layout from '../layouts/Layout';
 import { CustomNextPage } from '../types/types';
+import Landing from './landing';
 
 const Home: CustomNextPage = () => {
     return (
@@ -12,6 +13,7 @@ const Home: CustomNextPage = () => {
                 <link rel="icon" href="/symbol.ico" />
             </Head>
             <Header />
+            <Landing />
         </div>
     );
 };

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -6,6 +6,7 @@ import SecondLanding from './_second';
 const Landing = () => {
     const [scrollDirection, setScrollDirection] = useState(false);
     const [isFirst, setIsFirst] = useState(true);
+    const [count, setCount] = useState(0);
 
     useEffect(() => {
         const threshold = 0;
@@ -20,7 +21,13 @@ const Landing = () => {
                 return;
             }
             setScrollDirection(scrollY > lastScrollY ? true : false);
-            setIsFirst(scrollDirection ? true : false);
+            if (count == 0) {
+                if (scrollDirection) {
+                    setIsFirst(false);
+                    setCount(prev => prev + 1);
+                }
+            }
+            //setIsFirst(scrollDirection ? true : false);
             lastScrollY = scrollY > 0 ? scrollY : 0;
             ticking = false;
         };


### PR DESCRIPTION
*모바일랜딩에서 ReRenderPage의 깜빡거림 문제를 해결하였습니다.*

**해결방법**
우리가 생각한대로라면 스크롤을 한번 내리는 순간 `isFirst`는 `false`로 고정되어야하는데,
원본코드에서 `isFirst`가 `setScrollDirection`에 따라서 `true`로 설정되는 순간들이 좀 걸렸었는데,

이것을 `count`라는 state를 두어서 스크롤을 한 번 내리는 순간 절대로 `isFirst`를 다시 `true`로 돌리는 일이 없게 분기하였더니
깜빡거림 현상이 제거되었습니다.