### PR TITLE
Feat/header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import { FiMenu } from 'react-icons/fi';
 import { MdOutlineClose } from 'react-icons/md';
 import Link from 'next/link';
 
-function SideMenu() {
+function SideMenu({ theme }: { theme?: 'dark' | 'light' }) {
     function closeMenu() {
         if (typeof window !== 'undefined') {
             const sidebg = document.getElementById('sidebg');
@@ -20,8 +20,8 @@ function SideMenu() {
     return (
         <div className="fixed inset-0 z-[110] w-[100vw] invisible md:hidden" id="wrapper">
             <div className="fixed invisible bg-black/0 w-[100vw] inset-0 transition-all duration-400" id="sidebg">
-                <div className="fixed -left-[100vw] transition-[left] duration-500 w-80 h-full bg-white px-4 pt-6 shadow-lg" id="sidebar">
-                    <MdOutlineClose className="absolute top-9 right-4" size={20} onClick={closeMenu} />
+                <div className="fixed -left-[100vw] transition-[left] duration-500 w-80 h-full bg-white px-4 pt-2 shadow-lg" id="sidebar">
+                    <MdOutlineClose className="absolute top-5 right-4" size={20} onClick={closeMenu} />
                     <div className="font-impact border-b border-slate-200 py-2 mb-7 text-xl">KU HACKATHON</div>
                     <ul className="font-bold space-y-8">
                         <li>
@@ -59,14 +59,14 @@ function Header({ theme }: { theme?: 'dark' | 'light' }) {
 
     return (
         <>
-            <SideMenu />
+            <SideMenu theme={theme} />
             <header className={`z-[100] ${theme == 'dark' ? 'bg-ourBlack' : ''}`}>
-                <div className="mt-5 ml-1 flex z-70 items-center space-x-6 md:space-x-16">
-                    <FiMenu size={24} className="text-lg font-light md:hidden cursor-pointer" onClick={openMenu} />
+                <div className="ml-1 flex z-70 items-center space-x-6 md:space-x-16">
+                    <FiMenu size={24} stroke={`${theme == 'dark' ? 'white' : 'black'}`} className={`text-lg font-light md:hidden cursor-pointer`} onClick={openMenu} />
                     <Link href="/">
                         <button className={`${theme == 'dark' ? 'text-ourWhite' : ''} font-normal font-impact text-xl md:text-2xl md:mr-6`}>KU HACKATHON</button>
                     </Link>
-                    <ul className="hidden space-x-4 md:flex md:space-x-6 lg:space-x-8 font-semibold">
+                    <ul className={`${theme == 'dark' ? 'text-ourWhite' : ''} hidden space-x-4 md:flex md:space-x-6 lg:space-x-8 font-semibold`}>
                         <li>
                             <Link href="/about">ABOUT</Link>
                         </li>
@@ -82,9 +82,9 @@ function Header({ theme }: { theme?: 'dark' | 'light' }) {
                     </ul>
                 </div>
 
-                <div className="flex items-center font-light mt-4 mr-4 cursor-pointer md:mr-12">
+                <div className="flex items-center font-light mr-4 cursor-pointer md:mr-12">
                     <Link href="/mypage">
-                        <BsPerson size={22} />
+                        <BsPerson size={22} fill={`${theme == 'dark' ? 'white' : 'black'}`} />
                     </Link>
                 </div>
             </header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,7 +43,7 @@ function SideMenu() {
     );
 }
 
-function Header() {
+function Header({ theme }: { theme?: 'dark' | 'light' }) {
     function openMenu() {
         if (typeof window !== 'undefined') {
             const sidebg = document.getElementById('sidebg');
@@ -60,11 +60,11 @@ function Header() {
     return (
         <>
             <SideMenu />
-            <header className="z-[100]">
+            <header className={`z-[100] ${theme == 'dark' ? 'bg-ourBlack' : ''}`}>
                 <div className="mt-5 ml-1 flex z-70 items-center space-x-6 md:space-x-16">
                     <FiMenu size={24} className="text-lg font-light md:hidden cursor-pointer" onClick={openMenu} />
                     <Link href="/">
-                        <button className="font-normal font-impact text-xl md:text-2xl md:mr-6">KU HACKATHON</button>
+                        <button className={`${theme == 'dark' ? 'text-ourWhite' : ''} font-normal font-impact text-xl md:text-2xl md:mr-6`}>KU HACKATHON</button>
                     </Link>
                     <ul className="hidden space-x-4 md:flex md:space-x-6 lg:space-x-8 font-semibold">
                         <li>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -36,6 +36,9 @@
     header {
         @apply fixed top-0 w-full flex items-center justify-between z-50 px-4 py-4 transition-all lg:px-[9.375rem] lg:py-6;
     }
+    li {
+        color: inherit;
+    }
     a {
         color: inherit;
         text-decoration: none;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -34,7 +34,7 @@
         @apply text-xl sm:text-4xl font-bold;
     }
     header {
-        @apply fixed top-0 w-full flex items-center justify-between z-50 px-4 py-4 transition-all lg:px-10 lg:py-6;
+        @apply fixed top-0 w-full flex items-center justify-between z-50 px-4 py-4 transition-all lg:px-[9.375rem] lg:py-6;
     }
     a {
         color: inherit;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
             },
             colors: {
                 ourBlack: '#1D1D1D',
-                outWhite: '#F8F8F8',
+                ourWhite: '#F8F8F8',
             },
         },
     },


### PR DESCRIPTION
1. header에 theme 선택기능을 추가하였습니다.
-사용방법 예시) `<header theme='dark' />`
-theme에는`dark`, `light`만 지정할 수 있는데, 다크모드 사용해야 할 때만 `dark` 명시해주시면 되겠습니다.
(아무것도 지정 안하면 default는 기본 light 테마입니다)

2. header의 전체적인 패딩, header 요소들의 margin-top 등을 header의 세로축 정가운데로 오게 수정하였습니다.