### PR TITLE
feat: add Company Mypage, finetune some UIs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,8 +7,40 @@ const nextConfig = {
     async rewrites() {
         return [
             {
-                source: '/:path*',
-                destination: `https://${process.env.ENDPOINT}/:path*`,
+                source: '/users/:path*',
+                destination: `https://${process.env.ENDPOINT}/users/:path*`,
+            },
+            {
+                source: '/companies/:path*',
+                destination: `https://${process.env.ENDPOINT}/companies/:path*`,
+            },
+            {
+                source: '/auth/:path*',
+                destination: `https://${process.env.ENDPOINT}/auth/:path*`,
+            },
+            {
+                source: '/teams/:path*',
+                destination: `https://${process.env.ENDPOINT}/teams/:path*`,
+            },
+            {
+                source: '/project/:path*',
+                destination: `https://${process.env.ENDPOINT}/project/:path*`,
+            },
+            {
+                source: '/temp/:path*',
+                destination: `https://${process.env.ENDPOINT}/temp/:path*`,
+            },
+            {
+                source: '/image/:path*',
+                destination: `https://${process.env.ENDPOINT}/image/:path*`,
+            },
+            {
+                source: '/project/:path*',
+                destination: `https://${process.env.ENDPOINT}/project/:path*`,
+            },
+            {
+                source: '/chat/:path*',
+                destination: `https://${process.env.ENDPOINT}/chat/:path*`,
             },
         ];
     },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -92,7 +92,7 @@ function Footer({ theme }: { theme?: 'dark' | 'light' }) {
                             <Link href="/home">
                                 <span className={`font-semibold ${theme == 'dark' ? 'text-ourWhite' : 'text-ourBlack'} cursor-pointer`}>HOME PAGE</span>
                             </Link>
-                            <Link href={`${loginUserData.isLogin ? '/mypage' : '/login'}`}>
+                            <Link href={`${loginUserData.isLogin ? (loginUserData.user?.type == 'user' ? '/mypage' : '/myCompany') : '/login'}`}>
                                 <span className={`font-semibold ${theme == 'dark' ? 'text-ourWhite' : 'text-ourBlack'} cursor-pointer`}>MY PAGE</span>
                             </Link>
                             <span className="hidden lg:inline-block font-semibold text-ourBlack invisible">BLANK</span>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -99,7 +99,7 @@ function Header({ theme }: { theme?: 'dark' | 'light' }) {
                 </div>
 
                 <div className="flex items-center space-x-3 md:space-x-6 font-light cursor-pointer md:mr-12 lg:mr-16">
-                    <Link href={`${loginUserData.isLogin ? '/mypage' : '/login'}`}>
+                    <Link href={`${loginUserData.isLogin ? (loginUserData.user?.type == 'user' ? '/mypage' : '/myCompany') : '/login'}`}>
                         <BsPerson size={22} fill={`${theme == 'dark' ? 'white' : 'black'}`} />
                     </Link>
                     {/* {loginUserData.isLogin ? <FiLogOut size={20} stroke={`${theme == 'dark' ? 'white' : 'black'}`} onClick={handleLogOut} /> : null} */}

--- a/src/interfaces/company.ts
+++ b/src/interfaces/company.ts
@@ -1,0 +1,19 @@
+export interface Company {
+    id?: string;
+    name: string;
+    logo?: string;
+    alias?: string;
+    level?: number;
+    profile?: {
+        link?: {
+            github?: string;
+            blog?: string;
+            instagram?: string;
+        };
+        introduction?: string;
+        university?: string;
+        major?: string;
+        career?: string[];
+        _id?: string;
+    };
+}

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -1,6 +1,3 @@
-import { PositionType } from './position.types';
-import { ProviderType } from './provider.types';
-
 export interface User {
     type?: string;
     id?: string;

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -5,6 +5,8 @@ export interface User {
     type?: string;
     id?: string;
     name: string;
+    logo?: string;
+    alias?: string;
     email?: string;
     level?: number;
     team?: {

--- a/src/pages/enterprise/[id].tsx
+++ b/src/pages/enterprise/[id].tsx
@@ -46,6 +46,7 @@ function Enterprise() {
                             <a
                                 className="rounded-md w-[15rem] mt-2 mb-6 p-1.5 text-center bg-ourBlack cursor-pointer text-white flex items-center justify-center space-x-2"
                                 href={`https://www.instagram.com/${company?.profile?.link?.instagram}`}
+                                target="_blank"
                             >
                                 <FiInstagram stroke="white" size={20} /> <span className="text-white">Visit Instagram</span>
                             </a>
@@ -59,8 +60,8 @@ function Enterprise() {
                         <div className="flex flex-col">
                             <h4 className="font-bold text-xl break-words">💡저희는 아래와 같은 포지션을 찾고 있어요!</h4>
                             <div className="flex flex-col space-y-3 md:flex-row md:space-x-1 md:items-center md:space-y-0 mt-2">
-                                <span className="border-2 rounded-md w-full md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]">{company?.profile?.university}</span>
-                                <span className="border-2 rounded-md w-full md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]">{company?.profile?.major}</span>
+                                <span className="border-2 rounded-md w-full md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]">{company?.profile?.university || '-'}</span>
+                                <span className="border-2 rounded-md w-full md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]">{company?.profile?.major || '-'}</span>
                             </div>
                         </div>
                         <div className="flex flex-col">

--- a/src/pages/enterprise/[id].tsx
+++ b/src/pages/enterprise/[id].tsx
@@ -2,16 +2,21 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { axiosInstance } from '../../hooks/queries';
 import { Company } from '../../interfaces/company';
+import { FiInstagram } from 'react-icons/fi';
 
 function Enterprise() {
     const router = useRouter();
     const { id } = router.query;
     const [company, setCompany] = useState<Company>();
+    const [careers, setCareers] = useState<string[]>([]);
 
     useEffect(() => {
         async function fetchCompany() {
             try {
-                await axiosInstance.get(`/companies/${id}`).then(res => setCompany(res.data.data));
+                await axiosInstance.get(`/companies/${id}`).then(res => {
+                    setCompany(res.data.data);
+                    setCareers(res.data.data.profile.career);
+                });
             } catch (e) {
                 console.log(e);
             }
@@ -24,13 +29,50 @@ function Enterprise() {
         <main className="px-4 md:px-16 lg:px-20 xl:px-[13.375rem] bg-white md:bg-ourWhite mb-8 md:mb-0">
             <div className="w-full pt-[6rem] md:py-[8rem] min-h-[100vh] h-auto">
                 <section className="flex flex-col justify-center items-start mb-3 md:mb-5">
-                    <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">안녕하세요, {`${company?.alias}입니다!`}</h1>
-                    <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">우수한 인재도 발굴해보세요!</h1>
+                    <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">안녕하세요, {`${company?.name}입니다!`}</h1>
+                    <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">만나서 반가워요!</h1>
                 </section>
                 <section className="flex flex-col justify-center items-start mb-12 md:mb-8">
-                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">입력하신 정보는 본 사이트 랜딩페이지에서 기업 로고 클릭 시</p>
-                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">해당 정보가 가공된 페이지로 이동되어 보여집니다. </p>
+                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">저희 기업의 문화, 함께 하고픈 사람, 현재 채용 고려중인</p>
+                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">포지션들까지 간단하게 보고 가세요. </p>
                 </section>
+                <div className="w-full flex flex-col space-y-[3rem] lg:flex-row lg:space-y-0 items-center">
+                    <section className="w-full lg:min-w-[23rem] lg:w-[23rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[0.5rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:drop-shadow-[0px_0px_15px_rgba(32,135,255,0.15)] z-20">
+                        <div className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]">
+                            <img className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem] rounded-xl" src={`${company?.logo}`} />
+                        </div>
+                        <div className="flex flex-col space-y-2">
+                            <span className="rounded-md w-[15rem] mt-2 p-1.5 text-center text-2xl font-bold">{company?.name}</span>
+                            <a
+                                className="rounded-md w-[15rem] mt-2 mb-6 p-1.5 text-center bg-ourBlack cursor-pointer text-white flex items-center justify-center space-x-2"
+                                href={`https://www.instagram.com/${company?.profile?.link?.instagram}`}
+                            >
+                                <FiInstagram stroke="white" size={20} /> <span className="text-white">Visit Instagram</span>
+                            </a>
+                        </div>
+                    </section>
+                    <section className="w-full relative h-[33rem] pl-10 pr-10 py-10 md:pr-0 lg:px-10 xl:px-16 md:py-10 flex flex-col justify-center space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] ">
+                        <div className="flex flex-col">
+                            <h4 className="font-bold text-xl">✏️한 줄 소개</h4>
+                            <span className="border-2 rounded-md md:w-[31.25rem] mt-2 p-1.5">{company?.profile?.introduction}</span>
+                        </div>
+                        <div className="flex flex-col">
+                            <h4 className="font-bold text-xl break-words">💡저희는 아래와 같은 포지션을 찾고 있어요!</h4>
+                            <div className="flex flex-col space-y-3 md:flex-row md:space-x-1 md:items-center md:space-y-0 mt-2">
+                                <span className="border-2 rounded-md w-full md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]">{company?.profile?.university}</span>
+                                <span className="border-2 rounded-md w-full md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]">{company?.profile?.major}</span>
+                            </div>
+                        </div>
+                        <div className="flex flex-col">
+                            <h4 className="font-bold text-xl mb-2 break-words">🎈저희는 이러한 사람들과 함께 하고 싶어요!</h4>
+                            <div className="flex flex-col space-y-3 items-start h-auto">
+                                {careers.map(crr => (
+                                    <span className="border-2 rounded-md w-full md:w-[31.25rem] h-[2.5rem] p-1.5 mr-[1rem]">{crr}</span>
+                                ))}
+                            </div>
+                        </div>
+                    </section>
+                </div>
             </div>
         </main>
     );

--- a/src/pages/enterprise/[id].tsx
+++ b/src/pages/enterprise/[id].tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 
 function Enterprise() {
     const router = useRouter();
-    const { id } = router.query();
+    const { id } = router.query;
 }
 
 export default Enterprise;

--- a/src/pages/enterprise/[id].tsx
+++ b/src/pages/enterprise/[id].tsx
@@ -15,7 +15,24 @@ function Enterprise() {
                 console.log(e);
             }
         }
-    });
+
+        fetchCompany();
+    }, []);
+
+    return (
+        <main className="px-4 md:px-16 lg:px-20 xl:px-[13.375rem] bg-white md:bg-ourWhite mb-8 md:mb-0">
+            <div className="w-full pt-[6rem] md:py-[8rem] min-h-[100vh] h-auto">
+                <section className="flex flex-col justify-center items-start mb-3 md:mb-5">
+                    <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">참가자들에게 우리 기업을 홍보하고,</h1>
+                    <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">우수한 인재도 발굴해보세요!</h1>
+                </section>
+                <section className="flex flex-col justify-center items-start mb-12 md:mb-8">
+                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">입력하신 정보는 본 사이트 랜딩페이지에서 기업 로고 클릭 시</p>
+                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">해당 정보가 가공된 페이지로 이동되어 보여집니다. </p>
+                </section>
+            </div>
+        </main>
+    );
 }
 
 export default Enterprise;

--- a/src/pages/enterprise/[id].tsx
+++ b/src/pages/enterprise/[id].tsx
@@ -1,11 +1,12 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { axiosInstance } from '../../hooks/queries';
+import { Company } from '../../interfaces/company';
 
 function Enterprise() {
     const router = useRouter();
     const { id } = router.query;
-    const [company, setCompany] = useState();
+    const [company, setCompany] = useState<Company>();
 
     useEffect(() => {
         async function fetchCompany() {
@@ -23,7 +24,7 @@ function Enterprise() {
         <main className="px-4 md:px-16 lg:px-20 xl:px-[13.375rem] bg-white md:bg-ourWhite mb-8 md:mb-0">
             <div className="w-full pt-[6rem] md:py-[8rem] min-h-[100vh] h-auto">
                 <section className="flex flex-col justify-center items-start mb-3 md:mb-5">
-                    <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">참가자들에게 우리 기업을 홍보하고,</h1>
+                    <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">안녕하세요, {`${company?.alias}입니다!`}</h1>
                     <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">우수한 인재도 발굴해보세요!</h1>
                 </section>
                 <section className="flex flex-col justify-center items-start mb-12 md:mb-8">

--- a/src/pages/enterprise/[id].tsx
+++ b/src/pages/enterprise/[id].tsx
@@ -1,0 +1,8 @@
+import { useRouter } from 'next/router';
+
+function Enterprise() {
+    const router = useRouter();
+    const { id } = router.query();
+}
+
+export default Enterprise;

--- a/src/pages/enterprise/[id].tsx
+++ b/src/pages/enterprise/[id].tsx
@@ -1,8 +1,21 @@
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { axiosInstance } from '../../hooks/queries';
 
 function Enterprise() {
     const router = useRouter();
     const { id } = router.query;
+    const [company, setCompany] = useState();
+
+    useEffect(() => {
+        async function fetchCompany() {
+            try {
+                await axiosInstance.get(`/companies/${id}`).then(res => setCompany(res.data.data));
+            } catch (e) {
+                console.log(e);
+            }
+        }
+    });
 }
 
 export default Enterprise;

--- a/src/pages/enterprise/[id].tsx
+++ b/src/pages/enterprise/[id].tsx
@@ -55,17 +55,17 @@ function Enterprise() {
                     <section className="w-full relative h-[33rem] pl-10 pr-10 py-10 md:pr-0 lg:px-10 xl:px-16 md:py-10 flex flex-col justify-center space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] ">
                         <div className="flex flex-col">
                             <h4 className="font-bold text-xl">✏️한 줄 소개</h4>
-                            <span className="border-2 rounded-md md:w-[31.25rem] mt-2 p-1.5">{company?.profile?.introduction}</span>
+                            <span className="border-2 rounded-md md:w-[31.25rem] h-[2.5rem] mt-2 p-1.5">{company?.profile?.introduction || '-'}</span>
                         </div>
                         <div className="flex flex-col">
-                            <h4 className="font-bold text-xl break-words">💡저희는 아래와 같은 포지션을 찾고 있어요!</h4>
+                            <h4 className="font-bold text-xl break-words">💡저희는 다음과 같은 포지션을 모집하고 있어요!</h4>
                             <div className="flex flex-col space-y-3 md:flex-row md:space-x-1 md:items-center md:space-y-0 mt-2">
                                 <span className="border-2 rounded-md w-full md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]">{company?.profile?.university || '-'}</span>
                                 <span className="border-2 rounded-md w-full md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]">{company?.profile?.major || '-'}</span>
                             </div>
                         </div>
                         <div className="flex flex-col">
-                            <h4 className="font-bold text-xl mb-2 break-words">🎈저희는 이러한 사람들과 함께 하고 싶어요!</h4>
+                            <h4 className="font-bold text-xl mb-2 break-words">🎈저희는 이러한 분들과 함께 하고 싶어요!</h4>
                             <div className="flex flex-col space-y-3 items-start h-auto">
                                 {careers.map(crr => (
                                     <span className="border-2 rounded-md w-full md:w-[31.25rem] h-[2.5rem] p-1.5 mr-[1rem]">{crr}</span>

--- a/src/pages/landing/_desktop.tsx
+++ b/src/pages/landing/_desktop.tsx
@@ -1,8 +1,24 @@
 import { Parallax } from 'react-scroll-parallax';
 import Button from '../../components/Button';
 import Link from 'next/link';
+import { useState, useEffect } from 'react';
+import { axiosInstance } from '../../hooks/queries';
+import { Company } from '../../interfaces/company';
 
 const DeskTopLanding = () => {
+    const [companyList, setCompanyList] = useState<Company[]>([]);
+    useEffect(() => {
+        async function fetchCompanies() {
+            try {
+                await axiosInstance.get('/companies').then(res => setCompanyList(res.data.data));
+            } catch (e) {
+                console.log(e);
+            }
+        }
+
+        fetchCompanies();
+    }, []);
+
     return (
         <div>
             <div className="w-[100%] h-[45rem]">
@@ -61,7 +77,17 @@ const DeskTopLanding = () => {
                 <Parallax opacity={[0.1, 1]} translateY={[-50, -50]} startScroll={1000} endScroll={1300}>
                     <div>
                         <h3 className="mb-[2rem] font-semibold text-3xl">후원사</h3>
-                        <img src="/sponsors.svg" alt="companies" />
+                        <div className="w-[58.75rem] grid grid-cols-5 grid-flow-row gap-8">
+                            {companyList
+                                .filter(comp => !comp.alias?.includes('devkor'))
+                                .map(comp => (
+                                    <Link href={`/enterprise/${comp.id}`}>
+                                        <div className="h-[5rem] flex items-center justify-center">
+                                            <img src={`${comp.logo}`} className="cursor-pointer" />
+                                        </div>
+                                    </Link>
+                                ))}
+                        </div>
 
                         <Link href="/home">
                             <a>

--- a/src/pages/landing/_second.tsx
+++ b/src/pages/landing/_second.tsx
@@ -1,6 +1,9 @@
 import { useSpring, animated } from 'react-spring';
 import Button from '../../components/Button';
 import Link from 'next/link';
+import { useState, useEffect } from 'react';
+import { axiosInstance } from '../../hooks/queries';
+import { Company } from '../../interfaces/company';
 
 const SecondLanding = () => {
     const componentAnimation = useSpring({
@@ -11,11 +14,35 @@ const SecondLanding = () => {
             duration: 700,
         },
     });
+
+    const [companyList, setCompanyList] = useState<Company[]>([]);
+    useEffect(() => {
+        async function fetchCompanies() {
+            try {
+                await axiosInstance.get('/companies').then(res => setCompanyList(res.data.data));
+            } catch (e) {
+                console.log(e);
+            }
+        }
+
+        fetchCompanies();
+    }, []);
+
     return (
         <animated.div className="mt-[30rem] mb-0" style={{ ...componentAnimation }}>
             <div className="my-[10rem]">
                 <h3 className="text-center font-semibold text-xl mb-[5rem]">후원사</h3>
-                <img className="w-[90%] mx-auto" src="/sponsors-mobile.svg" alt="company" />
+                <div className="w-full grid grid-cols-3 grid-flow-row gap-8">
+                    {companyList
+                        .filter(comp => !comp.alias?.includes('devkor'))
+                        .map(comp => (
+                            <Link href={`/enterprise/${comp.id}`}>
+                                <div className="h-[5rem] flex items-center justify-center">
+                                    <img src={`${comp.logo}`} className="cursor-pointer" />
+                                </div>
+                            </Link>
+                        ))}
+                </div>
             </div>
             <Link href="/home">
                 <a>

--- a/src/pages/landing/_tablet.tsx
+++ b/src/pages/landing/_tablet.tsx
@@ -1,8 +1,24 @@
 import { Parallax } from 'react-scroll-parallax';
 import Button from '../../components/Button';
 import Link from 'next/link';
+import { useState, useEffect } from 'react';
+import { axiosInstance } from '../../hooks/queries';
+import { Company } from '../../interfaces/company';
 
 const TabletLanding = () => {
+    const [companyList, setCompanyList] = useState<Company[]>([]);
+    useEffect(() => {
+        async function fetchCompanies() {
+            try {
+                await axiosInstance.get('/companies').then(res => setCompanyList(res.data.data));
+            } catch (e) {
+                console.log(e);
+            }
+        }
+
+        fetchCompanies();
+    }, []);
+
     return (
         <div>
             <div className="w-[100%] h-[45rem]">
@@ -61,7 +77,17 @@ const TabletLanding = () => {
                 <Parallax opacity={[0.1, 1]} translateY={[-50, -50]} startScroll={900} endScroll={1200}>
                     <div>
                         <h3 className="mb-[5rem] font-semibold text-3xl">후원사</h3>
-                        <img src="/sponsors.svg" alt="companies" />
+                        <div className="w-full grid grid-cols-5 grid-flow-row gap-8">
+                            {companyList
+                                .filter(comp => !comp.alias?.includes('devkor'))
+                                .map(comp => (
+                                    <Link href={`/enterprise/${comp.id}`}>
+                                        <div className="h-[5rem] flex items-center justify-center">
+                                            <img src={`${comp.logo}`} className="cursor-pointer" />
+                                        </div>
+                                    </Link>
+                                ))}
+                        </div>
 
                         <Link href="/home">
                             <a>

--- a/src/pages/landing/labtop.tsx
+++ b/src/pages/landing/labtop.tsx
@@ -1,8 +1,24 @@
 import { Parallax } from 'react-scroll-parallax';
 import Button from '../../components/Button';
 import Link from 'next/link';
+import { axiosInstance } from '../../hooks/queries';
+import { useEffect, useState } from 'react';
+import { Company } from '../../interfaces/company';
 
 const LabTopLanding = () => {
+    const [companyList, setCompanyList] = useState<Company[]>([]);
+    useEffect(() => {
+        async function fetchCompanies() {
+            try {
+                await axiosInstance.get('/companies').then(res => setCompanyList(res.data.data));
+            } catch (e) {
+                console.log(e);
+            }
+        }
+
+        fetchCompanies();
+    }, []);
+
     return (
         <div>
             <div className="w-[100%] h-[45rem]">
@@ -61,7 +77,17 @@ const LabTopLanding = () => {
                 <Parallax opacity={[0.1, 1]} translateY={[-50, -50]} startScroll={1000} endScroll={1350}>
                     <div>
                         <h3 className="mb-[5rem] font-semibold text-3xl">후원사</h3>
-                        <img src="/sponsors.svg" alt="companies" />
+                        <div className="w-[58.75rem] grid grid-cols-5 grid-flow-row gap-8">
+                            {companyList
+                                .filter(comp => !comp.alias?.includes('devkor'))
+                                .map(comp => (
+                                    <Link href={`/enterprise/${comp.id}`}>
+                                        <div className="h-[5rem] flex items-center justify-center">
+                                            <img src={`${comp.logo}`} className="cursor-pointer" />
+                                        </div>
+                                    </Link>
+                                ))}
+                        </div>
 
                         <Link href="/home">
                             <a>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -14,7 +14,11 @@ const LoginPage: CustomNextPage = () => {
         const formPw = document.getElementById('formpw') as HTMLInputElement;
         const pw = formPw.value;
 
-        axiosInstance.post('/auth/local', { username: id, password: pw });
+        axiosInstance.post('/auth/local', { username: id, password: pw }).then(res => {
+            if (res.status == 302) {
+                window.location.href = 'https://connecthon.com';
+            }
+        });
     };
 
     return (

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -6,7 +6,7 @@ import { axiosInstance } from '../hooks/queries';
 const LoginPage: CustomNextPage = () => {
     const [isParticipantMode, setParticipantMode] = useState(true);
 
-    const handleCompanyLogin = (e: React.FormEvent) => {
+    const handleCompanyLogin = async (e: React.FormEvent) => {
         e.preventDefault();
         const formId = document.getElementById('formid') as HTMLInputElement;
         const id = formId.value;
@@ -14,11 +14,15 @@ const LoginPage: CustomNextPage = () => {
         const formPw = document.getElementById('formpw') as HTMLInputElement;
         const pw = formPw.value;
 
-        axiosInstance.post('/auth/local', { username: id, password: pw }).then(res => {
-            if (res.status == 302) {
-                window.location.href = 'https://connecthon.com';
-            }
-        });
+        try {
+            await axiosInstance.post('/auth/local', { username: id, password: pw }).then(res => {
+                if (res.status == 302) {
+                    window.location.href = 'https://connecthon.com';
+                }
+            });
+        } catch (e) {
+            console.log(e);
+        }
     };
 
     return (

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -36,7 +36,11 @@ function myCompany() {
         return null;
     }
 
-    return <main className="md:px-16 lg:px-20 xl:px-[13.375rem]">영역</main>;
+    return (
+        <main className="md:px-16 lg:px-20 xl:px-[13.375rem]">
+            <h1 className="font-bold text-lg">참가자들에게 기업에 대해서 소개해주세요!</h1>
+        </main>
+    );
 }
 
 export default myCompany;

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -69,8 +69,8 @@ function myCompany() {
                     <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">클릭했을 시 모달창으로 보여집니다.</p>
                 </section>
                 <form>
-                    <div className="w-full flex flex-col space-y-[3rem] md:flex-row md:space-y-0 items-center">
-                        <section className="w-full lg:min-w-[23rem] md:w-[23rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[3rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] md:drop-shadow-[0px_0px_15px_rgba(32,135,255,0.15)]">
+                    <div className="w-full flex flex-col space-y-[3rem] lg:flex-row lg:space-y-0 items-center">
+                        <section className="w-full lg:min-w-[23rem] lg:w-[23rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[3rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:drop-shadow-[0px_0px_15px_rgba(32,135,255,0.15)]">
                             <div className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]">
                                 <img className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]" src="/profile-default.jpg" />
                             </div>
@@ -82,7 +82,7 @@ function myCompany() {
                                 className="border-2 rounded-md w-[15rem] mt-2 mb-6 p-1.5"
                             />
                         </section>
-                        <section className="w-full h-[33rem] p-10 md:px-16 md:py-10 flex flex-col space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] md:filter-none">
+                        <section className="w-full h-[33rem] p-10 md:px-16 md:py-10 flex flex-col space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:filter-none">
                             <div className="flex flex-col">
                                 <label htmlFor="introduction" className="font-bold text-lg">
                                     한 줄 소개

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -32,7 +32,11 @@ function myCompany() {
         getSessionUser();
     }, []);
 
-    <main className="md:px-16 lg:px-20 xl:px-[13.375rem]">영역</main>;
+    if (loginUserState.isLogin == false) {
+        return null;
+    }
+
+    return <main className="md:px-16 lg:px-20 xl:px-[13.375rem]">영역</main>;
 }
 
 export default myCompany;

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -51,33 +51,33 @@ function myCompany() {
         mode: 'onSubmit',
     });
 
-    // useEffect(() => {
-    //     const getSessionUser = async () => {
-    //         try {
-    //             const response = await axiosInstance.get('/auth/user');
-    //             if (response.status != 401) {
-    //                 if (response.data.type == 'user') {
-    //                     alert('기업 계정만 접근 가능한 페이지입니다.');
-    //                     router.back();
-    //                 } else if (response.data.type == 'company') {
-    //                     setLoginUserState({
-    //                         isLogin: true,
-    //                         user: response.data,
-    //                     });
-    //                 }
-    //             }
-    //         } catch (err) {
-    //             alert('로그인이 필요한 서비스입니다.');
-    //             router.push('/login');
-    //         }
-    //     };
+    useEffect(() => {
+        const getSessionUser = async () => {
+            try {
+                const response = await axiosInstance.get('/auth/user');
+                if (response.status != 401) {
+                    if (response.data.type == 'user') {
+                        alert('기업 계정만 접근 가능한 페이지입니다.');
+                        router.back();
+                    } else if (response.data.type == 'company') {
+                        setLoginUserState({
+                            isLogin: true,
+                            user: response.data,
+                        });
+                    }
+                }
+            } catch (err) {
+                alert('로그인이 필요한 서비스입니다.');
+                router.push('/login');
+            }
+        };
 
-    //     getSessionUser();
-    // }, []);
+        getSessionUser();
+    }, []);
 
-    // if (loginUserState.isLogin == false) {
-    //     return null;
-    // }
+    if (loginUserState.isLogin == false) {
+        return null;
+    }
 
     //처음에 경력창 인풋 개수를 섧정해주어야 함.
     useEffect(() => {

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -3,42 +3,91 @@ import { useRecoilState } from 'recoil';
 import { loginRecoilState } from '../recoil/loginuser';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import { SubmitHandler, useForm } from 'react-hook-form';
 
 function myCompany() {
     const router = useRouter();
     const [loginUserState, setLoginUserState] = useRecoilState(loginRecoilState);
 
-    useEffect(() => {
-        const getSessionUser = async () => {
-            try {
-                const response = await axiosInstance.get('/auth/user');
-                if (response.status != 401) {
-                    if (response.data.type == 'user') {
-                        alert('기업 계정만 접근 가능한 페이지입니다.');
-                        router.back();
-                    } else if (response.data.type == 'company') {
-                        setLoginUserState({
-                            isLogin: true,
-                            user: response.data,
-                        });
-                    }
-                }
-            } catch (err) {
-                alert('로그인이 필요한 서비스입니다.');
-                router.push('/login');
-            }
-        };
+    //useForm에 최종적으로 들어갈 오브젝트타입
+    type FormValues = {
+        name: string;
+        email: string;
+        team: string;
+        github: string;
+        blog: string;
+        instagram: string;
+        introduction: string;
+        img: string;
+        position: string;
+        university: string;
+        major: string;
+        career: string[];
+        teamName: string;
+    };
 
-        getSessionUser();
-    }, []);
+    //react-hook-form
+    const { control, register, handleSubmit } = useForm<FormValues>({
+        mode: 'onSubmit',
+    });
 
-    if (loginUserState.isLogin == false) {
-        return null;
-    }
+    // useEffect(() => {
+    //     const getSessionUser = async () => {
+    //         try {
+    //             const response = await axiosInstance.get('/auth/user');
+    //             if (response.status != 401) {
+    //                 if (response.data.type == 'user') {
+    //                     alert('기업 계정만 접근 가능한 페이지입니다.');
+    //                     router.back();
+    //                 } else if (response.data.type == 'company') {
+    //                     setLoginUserState({
+    //                         isLogin: true,
+    //                         user: response.data,
+    //                     });
+    //                 }
+    //             }
+    //         } catch (err) {
+    //             alert('로그인이 필요한 서비스입니다.');
+    //             router.push('/login');
+    //         }
+    //     };
+
+    //     getSessionUser();
+    // }, []);
+
+    // if (loginUserState.isLogin == false) {
+    //     return null;
+    // }
 
     return (
-        <main className="md:px-16 lg:px-20 xl:px-[13.375rem]">
-            <h1 className="font-bold text-lg">참가자들에게 기업에 대해서 소개해주세요!</h1>
+        <main className="px-4 md:px-16 lg:px-20 xl:px-[13.375rem] bg-white md:bg-ourWhite mb-8 md:mb-0">
+            <div className="w-full pt-[6rem] md:py-[8rem] min-h-[100vh] h-auto">
+                <section className="flex flex-col justify-center items-start mb-3 md:mb-5">
+                    <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">참가자들에게 우리 기업을 홍보하고,</h1>
+                    <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">우수한 인재도 발굴해보세요!</h1>
+                </section>
+                <section className="flex flex-col justify-center items-start mb-12 md:mb-8">
+                    <p className="text-xs md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">입력하신 정보는 본 사이트 랜딩페이지에서 기업 로고를</p>
+                    <p className="text-xs md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">클릭했을 시 모달창으로 보여집니다.</p>
+                </section>
+                <form>
+                    <div className="w-full flex flex-col space-y-[3rem] md:flex-row md:space-y-0 items-center">
+                        <section className="w-full md:min-w-[20rem] md:w-[20rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[3rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] md:drop-shadow-[0px_0px_18px_rgba(32,135,255,0.1)]">
+                            <div className="w-[11rem] h-[11rem] md:w-[15rem] md:h-[15rem]">
+                                <img className="w-[11rem] h-[11rem] md:w-[15rem] md:h-[15rem]" src="/profile-default.jpg" />
+                            </div>
+                            <input
+                                {...register('name')}
+                                type="text"
+                                defaultValue={`${loginUserState.user?.name}`}
+                                placeholder="노출될 기업명을 입력해주세요"
+                                className="border-2 rounded-md w-[15rem] mt-2 mb-6 p-1.5"
+                            />
+                        </section>
+                        <section className="w-full h-[33rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] md:filter-none"></section>
+                    </div>
+                </form>
+            </div>
         </main>
     );
 }

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -64,6 +64,7 @@ function myCompany() {
                             isLogin: true,
                             user: response.data,
                         });
+                        setNumCareerInput(response.data.profile.career.length);
                     }
                 }
             } catch (err) {
@@ -78,17 +79,6 @@ function myCompany() {
     if (loginUserState.isLogin == false) {
         return null;
     }
-
-    //처음에 경력창 인풋 개수를 섧정해주어야 함.
-    useEffect(() => {
-        if (loginUserState.user?.profile?.career) {
-            if (loginUserState.user?.profile?.career?.length >= 1) {
-                setNumCareerInput(loginUserState.user?.profile?.career.length);
-            }
-        } else {
-            setNumCareerInput(1);
-        }
-    }, []);
 
     return (
         <main className="px-4 md:px-16 lg:px-20 xl:px-[13.375rem] bg-white md:bg-ourWhite mb-8 md:mb-0">

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -2,9 +2,35 @@ import { axiosInstance } from '../hooks/queries';
 import { useRecoilState } from 'recoil';
 import { loginRecoilState } from '../recoil/loginuser';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 
 function myCompany() {
+    const router = useRouter();
     const [loginUserState, setLoginUserState] = useRecoilState(loginRecoilState);
+
+    useEffect(() => {
+        const getSessionUser = async () => {
+            try {
+                const response = await axiosInstance.get('/auth/user');
+                if (response.status != 401) {
+                    if (response.data.type == 'user') {
+                        alert('기업 계정만 접근 가능한 페이지입니다.');
+                        router.back();
+                    } else if (response.data.type == 'company') {
+                        setLoginUserState({
+                            isLogin: true,
+                            user: response.data,
+                        });
+                    }
+                }
+            } catch (err) {
+                alert('로그인이 필요한 서비스입니다.');
+                router.push('/login');
+            }
+        };
+
+        getSessionUser();
+    }, []);
 
     <main className="md:px-16 lg:px-20 xl:px-[13.375rem]">영역</main>;
 }

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -9,21 +9,19 @@ function myCompany() {
     const router = useRouter();
     const [loginUserState, setLoginUserState] = useRecoilState(loginRecoilState);
 
+    //경력(career) 관련
+    const [numCareerInput, setNumCareerInput] = useState<number>(1);
+
     //useForm에 최종적으로 들어갈 오브젝트타입
     type FormValues = {
         name: string;
-        email: string;
-        team: string;
         github: string;
         blog: string;
         instagram: string;
         introduction: string;
-        img: string;
-        position: string;
         university: string;
         major: string;
         career: string[];
-        teamName: string;
     };
 
     //react-hook-form
@@ -67,14 +65,14 @@ function myCompany() {
                     <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">우수한 인재도 발굴해보세요!</h1>
                 </section>
                 <section className="flex flex-col justify-center items-start mb-12 md:mb-8">
-                    <p className="text-xs md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">입력하신 정보는 본 사이트 랜딩페이지에서 기업 로고를</p>
-                    <p className="text-xs md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">클릭했을 시 모달창으로 보여집니다.</p>
+                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">입력하신 정보는 본 사이트 랜딩페이지에서 기업 로고를</p>
+                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">클릭했을 시 모달창으로 보여집니다.</p>
                 </section>
                 <form>
                     <div className="w-full flex flex-col space-y-[3rem] md:flex-row md:space-y-0 items-center">
-                        <section className="w-full md:min-w-[20rem] md:w-[20rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[3rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] md:drop-shadow-[0px_0px_18px_rgba(32,135,255,0.1)]">
-                            <div className="w-[11rem] h-[11rem] md:w-[15rem] md:h-[15rem]">
-                                <img className="w-[11rem] h-[11rem] md:w-[15rem] md:h-[15rem]" src="/profile-default.jpg" />
+                        <section className="w-full lg:min-w-[23rem] md:w-[23rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[3rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] md:drop-shadow-[0px_0px_15px_rgba(32,135,255,0.15)]">
+                            <div className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]">
+                                <img className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]" src="/profile-default.jpg" />
                             </div>
                             <input
                                 {...register('name')}
@@ -84,7 +82,53 @@ function myCompany() {
                                 className="border-2 rounded-md w-[15rem] mt-2 mb-6 p-1.5"
                             />
                         </section>
-                        <section className="w-full h-[33rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] md:filter-none"></section>
+                        <section className="w-full h-[33rem] p-10 md:px-16 md:py-10 flex flex-col space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] md:filter-none">
+                            <div className="flex flex-col">
+                                <label htmlFor="introduction" className="font-bold text-lg">
+                                    한 줄 소개
+                                </label>
+                                <input
+                                    {...register('introduction')}
+                                    type="text"
+                                    placeholder="기업을 한 줄로 소개해주세요!"
+                                    defaultValue={loginUserState.user?.profile?.introduction}
+                                    className="border-2 rounded-md md:w-[31.25rem] mt-2 p-1.5"
+                                />
+                            </div>
+                            <div className="flex flex-col">
+                                <label htmlFor="recruiting" className="font-bold text-lg">
+                                    채용중인 포지션 (최대 2개)
+                                </label>
+                                <div className="flex flex-col space-y-3 md:flex-row md:space-x-1 md:items-center md:space-y-0 mt-2">
+                                    <input
+                                        {...register('university')}
+                                        type="text"
+                                        placeholder="포지션을 입력해주세요!"
+                                        defaultValue={loginUserState.user?.profile?.university}
+                                        className="border-2 rounded-md md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]"
+                                    />
+                                    <input
+                                        {...register('major')}
+                                        type="text"
+                                        placeholder="포지션을 입력해주세요!"
+                                        defaultValue={loginUserState.user?.profile?.major}
+                                        className="border-2 rounded-md md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]"
+                                    />
+                                </div>
+                            </div>
+                            <div className="flex flex-col">
+                                <label htmlFor="rightppl" className="font-bold text-lg">
+                                    추구하는 인재상 (최대 3개)
+                                </label>
+                                <input
+                                    {...register('career')}
+                                    type="text"
+                                    placeholder="추구하는 인재상을 입력해주세요!"
+                                    defaultValue={loginUserState.user?.profile?.introduction}
+                                    className="border-2 rounded-md md:w-[31.25rem] mt-2 p-1.5"
+                                />
+                            </div>
+                        </section>
                     </div>
                 </form>
             </div>

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -42,15 +42,6 @@ function myCompany() {
             })
             .then(res => console.log(res.data));
 
-        // 팀 이름을 받으면 이렇게 데이터를 전송할 거에요!
-        // axiosInstance
-        //     .put(`/teams/${data.teamName}/users`, {
-        //         data: {
-        //             users: loginUserState.user?.id,
-        //         },
-        //     })
-        //     .then(res => console.log(res.data));
-
         alert('프로필이 수정되었습니다!');
         console.log(loginUserState.user);
     };
@@ -87,6 +78,17 @@ function myCompany() {
     // if (loginUserState.isLogin == false) {
     //     return null;
     // }
+
+    //처음에 경력창 인풋 개수를 섧정해주어야 함.
+    useEffect(() => {
+        if (loginUserState.user?.profile?.career) {
+            if (loginUserState.user?.profile?.career?.length >= 1) {
+                setNumCareerInput(loginUserState.user?.profile?.career.length);
+            }
+        } else {
+            setNumCareerInput(1);
+        }
+    }, []);
 
     return (
         <main className="px-4 md:px-16 lg:px-20 xl:px-[13.375rem] bg-white md:bg-ourWhite mb-8 md:mb-0">

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -95,7 +95,7 @@ function myCompany() {
                     <div className="w-full flex flex-col space-y-[3rem] lg:flex-row lg:space-y-0 items-center">
                         <section className="w-full lg:min-w-[23rem] lg:w-[23rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:drop-shadow-[0px_0px_15px_rgba(32,135,255,0.15)] z-20">
                             <div className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]">
-                                <img className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]" src={`${loginUserState.user?.logo || '/profile-default.jpg'}`} />
+                                <img className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem] rounded-xl" src={`${loginUserState.user?.logo || '/profile-default.jpg'}`} />
                             </div>
                             <div className="flex flex-col space-y-2">
                                 <input
@@ -109,7 +109,7 @@ function myCompany() {
                                     {...register('instagram')}
                                     type="text"
                                     defaultValue={`${loginUserState.user?.profile?.link?.instagram}`}
-                                    placeholder="인스타그램 아이디를 입력해주세요"
+                                    placeholder="(@ 제외) 인스타그램 아이디를 입력해주세요"
                                     className="border-2 rounded-md w-[15rem] mt-2 mb-6 p-1.5"
                                 />
                             </div>

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -93,7 +93,7 @@ function myCompany() {
                 </section>
                 <form onSubmit={handleSubmit(onSubmit)}>
                     <div className="w-full flex flex-col space-y-[3rem] lg:flex-row lg:space-y-0 items-center">
-                        <section className="w-full lg:min-w-[23rem] lg:w-[23rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:drop-shadow-[0px_0px_15px_rgba(32,135,255,0.15)]">
+                        <section className="w-full lg:min-w-[23rem] lg:w-[23rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:drop-shadow-[0px_0px_15px_rgba(32,135,255,0.15)] z-20">
                             <div className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]">
                                 <img className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]" src="/profile-default.jpg" />
                             </div>
@@ -114,7 +114,7 @@ function myCompany() {
                                 />
                             </div>
                         </section>
-                        <section className="w-full relative h-[33rem] pl-10 pr-10 py-10 md:pr-0 lg:px-10 xl:px-16 md:py-10 flex flex-col space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:filter-none">
+                        <section className="w-full relative h-[33rem] pl-10 pr-10 py-10 md:pr-0 lg:px-10 xl:px-16 md:py-10 flex flex-col space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] ">
                             <div className="flex flex-col">
                                 <label htmlFor="introduction" className="font-bold text-lg">
                                     한 줄 소개

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -88,8 +88,8 @@ function myCompany() {
                     <h1 className="text-[1.35rem] leading-[1.55rem] md:leading-[2.813rem] md:text-[2.125rem] font-extrabold">우수한 인재도 발굴해보세요!</h1>
                 </section>
                 <section className="flex flex-col justify-center items-start mb-12 md:mb-8">
-                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">입력하신 정보는 본 사이트 랜딩페이지에서 기업 로고를</p>
-                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">클릭했을 시 모달창으로 보여집니다.</p>
+                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">입력하신 정보는 본 사이트 랜딩페이지에서 기업 로고 클릭 시</p>
+                    <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">해당 정보가 가공된 페이지로 이동되어 보여집니다. </p>
                 </section>
                 <form onSubmit={handleSubmit(onSubmit)}>
                     <div className="w-full flex flex-col space-y-[3rem] lg:flex-row lg:space-y-0 items-center">

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -95,7 +95,7 @@ function myCompany() {
                     <div className="w-full flex flex-col space-y-[3rem] lg:flex-row lg:space-y-0 items-center">
                         <section className="w-full lg:min-w-[23rem] lg:w-[23rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:drop-shadow-[0px_0px_15px_rgba(32,135,255,0.15)] z-20">
                             <div className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]">
-                                <img className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]" src="/profile-default.jpg" />
+                                <img className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]" src={`${loginUserState.user?.logo || '/profile-default.jpg'}`} />
                             </div>
                             <div className="flex flex-col space-y-2">
                                 <input

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -1,3 +1,5 @@
+import { AiOutlinePlusCircle } from 'react-icons/ai';
+import { TbTrashOff } from 'react-icons/tb';
 import { axiosInstance } from '../hooks/queries';
 import { useRecoilState } from 'recoil';
 import { loginRecoilState } from '../recoil/loginuser';
@@ -15,8 +17,6 @@ function myCompany() {
     //useForm에 최종적으로 들어갈 오브젝트타입
     type FormValues = {
         name: string;
-        github: string;
-        blog: string;
         instagram: string;
         introduction: string;
         university: string;
@@ -24,8 +24,39 @@ function myCompany() {
         career: string[];
     };
 
+    const onSubmit: SubmitHandler<FormValues> = (data: FormValues) => {
+        const updatedProfile = {
+            link: {
+                instagram: data.instagram,
+            },
+            introduction: data.introduction,
+            university: data.university,
+            major: data.major,
+            career: data.career.slice(0, numCareerInput),
+        };
+        console.log(loginUserState.user?.id);
+        axiosInstance
+            .put(`/companies/${loginUserState.user?.id}/profile`, {
+                profile: updatedProfile,
+                name: data.name,
+            })
+            .then(res => console.log(res.data));
+
+        // 팀 이름을 받으면 이렇게 데이터를 전송할 거에요!
+        // axiosInstance
+        //     .put(`/teams/${data.teamName}/users`, {
+        //         data: {
+        //             users: loginUserState.user?.id,
+        //         },
+        //     })
+        //     .then(res => console.log(res.data));
+
+        alert('프로필이 수정되었습니다!');
+        console.log(loginUserState.user);
+    };
+
     //react-hook-form
-    const { control, register, handleSubmit } = useForm<FormValues>({
+    const { register, handleSubmit } = useForm<FormValues>({
         mode: 'onSubmit',
     });
 
@@ -68,21 +99,30 @@ function myCompany() {
                     <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">입력하신 정보는 본 사이트 랜딩페이지에서 기업 로고를</p>
                     <p className="text-sm md:leading-[1.438rem] md:text-[0.938rem] text-ourGrey font-medium">클릭했을 시 모달창으로 보여집니다.</p>
                 </section>
-                <form>
+                <form onSubmit={handleSubmit(onSubmit)}>
                     <div className="w-full flex flex-col space-y-[3rem] lg:flex-row lg:space-y-0 items-center">
-                        <section className="w-full lg:min-w-[23rem] lg:w-[23rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[3rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:drop-shadow-[0px_0px_15px_rgba(32,135,255,0.15)]">
+                        <section className="w-full lg:min-w-[23rem] lg:w-[23rem] h-[22rem] md:h-[33rem] flex flex-col justify-center items-center space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:drop-shadow-[0px_0px_15px_rgba(32,135,255,0.15)]">
                             <div className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]">
                                 <img className="w-[11rem] h-[11rem] lg:w-[15rem] lg:h-[15rem]" src="/profile-default.jpg" />
                             </div>
-                            <input
-                                {...register('name')}
-                                type="text"
-                                defaultValue={`${loginUserState.user?.name}`}
-                                placeholder="노출될 기업명을 입력해주세요"
-                                className="border-2 rounded-md w-[15rem] mt-2 mb-6 p-1.5"
-                            />
+                            <div className="flex flex-col space-y-2">
+                                <input
+                                    {...register('name')}
+                                    type="text"
+                                    defaultValue={`${loginUserState.user?.name}`}
+                                    placeholder="노출될 기업명을 입력해주세요"
+                                    className="border-2 rounded-md w-[15rem] mt-2 p-1.5"
+                                />
+                                <input
+                                    {...register('instagram')}
+                                    type="text"
+                                    defaultValue={`${loginUserState.user?.profile?.link?.instagram}`}
+                                    placeholder="인스타그램 아이디를 입력해주세요"
+                                    className="border-2 rounded-md w-[15rem] mt-2 mb-6 p-1.5"
+                                />
+                            </div>
                         </section>
-                        <section className="w-full h-[33rem] p-10 md:px-16 md:py-10 flex flex-col space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:filter-none">
+                        <section className="w-full relative h-[33rem] pl-10 pr-10 py-10 md:pr-0 lg:px-10 xl:px-16 md:py-10 flex flex-col space-y-[2rem] bg-white rounded-2xl drop-shadow-[0px_0px_12px_rgba(32,135,255,0.1)] lg:filter-none">
                             <div className="flex flex-col">
                                 <label htmlFor="introduction" className="font-bold text-lg">
                                     한 줄 소개
@@ -117,17 +157,61 @@ function myCompany() {
                                 </div>
                             </div>
                             <div className="flex flex-col">
-                                <label htmlFor="rightppl" className="font-bold text-lg">
-                                    추구하는 인재상 (최대 3개)
+                                <label htmlFor="rightppl" className="font-bold text-lg mb-2">
+                                    추구하는 인재상 (최대 3가지)
                                 </label>
-                                <input
-                                    {...register('career')}
-                                    type="text"
-                                    placeholder="추구하는 인재상을 입력해주세요!"
-                                    defaultValue={loginUserState.user?.profile?.introduction}
-                                    className="border-2 rounded-md md:w-[31.25rem] mt-2 p-1.5"
-                                />
+                                <div className="flex flex-col space-y-3 items-start h-[9rem]">
+                                    {Array.from({ length: numCareerInput }).map((item, idx) => {
+                                        return (
+                                            <div className="flex items-center" key={idx}>
+                                                <input
+                                                    {...register(`career.${idx}`)}
+                                                    defaultValue={
+                                                        loginUserState.user?.profile?.career && loginUserState.user?.profile?.career.length >= 1 ? loginUserState.user?.profile?.career[idx] : ' '
+                                                    }
+                                                    type="text"
+                                                    placeholder="인재상을 입력해주세요"
+                                                    className="border-2 rounded-md md:w-[15rem] h-[2.5rem] p-1.5 mr-[1rem]"
+                                                />
+                                                {idx == numCareerInput - 1 ? (
+                                                    <>
+                                                        <AiOutlinePlusCircle
+                                                            onClick={() => {
+                                                                if (numCareerInput == 3) {
+                                                                    alert('최대 3개까지 입력 가능합니다.');
+                                                                } else {
+                                                                    setNumCareerInput(numCareerInput + 1);
+                                                                }
+                                                            }}
+                                                            className="fill-[#2087FF]"
+                                                            size={24}
+                                                        />
+                                                        <TbTrashOff
+                                                            onClick={() => {
+                                                                if (numCareerInput === 1) {
+                                                                    return;
+                                                                } else {
+                                                                    setNumCareerInput(numCareerInput - 1);
+                                                                }
+                                                            }}
+                                                            className="stroke-[#c02224] mx-1"
+                                                            size={24}
+                                                        />
+                                                    </>
+                                                ) : null}
+                                            </div>
+                                        );
+                                    })}
+                                </div>
                             </div>
+                            <button
+                                className="absolute bottom-5 w-[calc(100%-5rem)] xl:w-[calc(100%-8rem)] mr-10 xl:mr-16 bg-[#2087FF] rounded-full h-[2.5rem] text-white text-base tracking-wider cursor-pointer"
+                                onClick={() => {
+                                    router.push('/myCompany');
+                                }}
+                            >
+                                SAVE
+                            </button>
                         </section>
                     </div>
                 </form>

--- a/src/pages/myCompany.tsx
+++ b/src/pages/myCompany.tsx
@@ -1,0 +1,12 @@
+import { axiosInstance } from '../hooks/queries';
+import { useRecoilState } from 'recoil';
+import { loginRecoilState } from '../recoil/loginuser';
+import { useEffect, useState } from 'react';
+
+function myCompany() {
+    const [loginUserState, setLoginUserState] = useRecoilState(loginRecoilState);
+
+    <main className="md:px-16 lg:px-20 xl:px-[13.375rem]">영역</main>;
+}
+
+export default myCompany;

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -108,7 +108,7 @@ const MyPage: CustomNextPage = () => {
                                                 }
                                             }}
                                         />
-                                        {onMail ? <img src="/mail-text.svg" alt="mail-text" className="absolute left-6 w-[3rem] drop-shadow-lg" /> : null}
+                                        {onMail ? <img src="/mail-text.svg" alt="mail-text" className="absolute -left-3 w-[3rem] drop-shadow-lg" /> : null}
                                     </div>
                                     <div className="mx-2">
                                         <Link href={loginUserState.user?.profile?.link?.instagram ? `https://www.instagram.com/${loginUserState.user?.profile?.link.instagram}` : ''}>
@@ -125,7 +125,7 @@ const MyPage: CustomNextPage = () => {
                                             </a>
                                         </Link>
 
-                                        {onInstagram ? <img src="/instagram-text.svg" alt="mail-text" className="absolute left-[2.8rem] drop-shadow-lg" /> : null}
+                                        {onInstagram ? <img src="/instagram-text.svg" alt="mail-text" className="absolute left-2.5 drop-shadow-lg" /> : null}
                                     </div>
                                     <div>
                                         <Link href={loginUserState.user?.profile?.link?.github ? `https://github.com/${loginUserState.user?.profile?.link.github}` : ''}>
@@ -142,7 +142,7 @@ const MyPage: CustomNextPage = () => {
                                             </a>
                                         </Link>
 
-                                        {onGithub ? <img src="/github-text.svg" alt="github-text" className="absolute left-[6.2rem] drop-shadow-lg" /> : null}
+                                        {onGithub ? <img src="/github-text.svg" alt="github-text" className="absolute left-[4rem] drop-shadow-lg" /> : null}
                                     </div>
                                     <div>
                                         <Link href={loginUserState.user?.profile?.link?.blog ? loginUserState.user?.profile?.link.blog : ''}>

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -30,10 +30,8 @@ const MyPage: CustomNextPage = () => {
                             user: { ...response.data, name: response.data.name.first + (response.data.name.last || '') },
                         });
                     } else if (response.data.type == 'company') {
-                        setLoginUserState({
-                            isLogin: true,
-                            user: response.data,
-                        });
+                        alert('참가자 계정만 접근 가능한 페이지입니다.');
+                        router.back();
                     }
                 }
             } catch (err) {

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -104,52 +104,63 @@ const MyPage: CustomNextPage = () => {
                                                 if (loginUserState.user?.email) {
                                                     window.open(`mailto:${loginUserState.user?.email}`);
                                                 } else {
-                                                    alert('해당 참가자의 이메일 정보가 없어요!');
+                                                    alert('해당 참가자의 이메일 정보가 없습니다!');
                                                 }
                                             }}
                                         />
                                         {onMail ? <img src="/mail-text.svg" alt="mail-text" className="absolute -left-3 w-[3rem] drop-shadow-lg" /> : null}
                                     </div>
                                     <div className="mx-2">
-                                        <Link href={loginUserState.user?.profile?.link?.instagram ? `https://www.instagram.com/${loginUserState.user?.profile?.link.instagram}` : ''}>
-                                            <a>
-                                                <FiInstagram
-                                                    className="text-2xl cursor-pointer"
-                                                    onMouseOver={() => {
-                                                        setOnInstagram(true);
-                                                    }}
-                                                    onMouseOut={() => {
-                                                        setOnInstagram(false);
-                                                    }}
-                                                />
-                                            </a>
-                                        </Link>
+                                        <FiInstagram
+                                            className="text-2xl cursor-pointer"
+                                            onMouseOver={() => {
+                                                setOnInstagram(true);
+                                            }}
+                                            onMouseOut={() => {
+                                                setOnInstagram(false);
+                                            }}
+                                            onClick={() => {
+                                                if (loginUserState.user?.profile?.link?.instagram) {
+                                                    window.open(`https://instagram.com/${loginUserState.user?.profile?.link?.instagram}`);
+                                                } else {
+                                                    alert('해당 참가자의 인스타그램 계정 정보가 없습니다!');
+                                                }
+                                            }}
+                                        />
 
                                         {onInstagram ? <img src="/instagram-text.svg" alt="mail-text" className="absolute left-2.5 drop-shadow-lg" /> : null}
                                     </div>
                                     <div>
-                                        <Link href={loginUserState.user?.profile?.link?.github ? `https://github.com/${loginUserState.user?.profile?.link.github}` : ''}>
-                                            <a>
-                                                <FiGithub
-                                                    className="text-2xl cursor-pointer"
-                                                    onMouseOver={() => {
-                                                        setOnGithub(true);
-                                                    }}
-                                                    onMouseOut={() => {
-                                                        setOnGithub(false);
-                                                    }}
-                                                />
-                                            </a>
-                                        </Link>
+                                        <FiGithub
+                                            className="text-2xl cursor-pointer"
+                                            onMouseOver={() => {
+                                                setOnGithub(true);
+                                            }}
+                                            onMouseOut={() => {
+                                                setOnGithub(false);
+                                            }}
+                                            onClick={() => {
+                                                if (loginUserState.user?.profile?.link?.github) {
+                                                    window.open(`https://github.com/${loginUserState.user?.profile?.link.github}`);
+                                                } else {
+                                                    alert('해당 참가자의 Github 계정 정보가 없습니다!');
+                                                }
+                                            }}
+                                        />
 
                                         {onGithub ? <img src="/github-text.svg" alt="github-text" className="absolute left-[4rem] drop-shadow-lg" /> : null}
                                     </div>
                                     <div>
-                                        <Link href={loginUserState.user?.profile?.link?.blog ? loginUserState.user?.profile?.link.blog : ''}>
-                                            <a>
-                                                <FiHome className="text-2xl cursor-pointer" />
-                                            </a>
-                                        </Link>
+                                        <FiHome
+                                            className="text-2xl cursor-pointer"
+                                            onClick={() => {
+                                                if (loginUserState.user?.profile?.link?.blog) {
+                                                    window.open(`${loginUserState.user?.profile?.link?.blog}`);
+                                                } else {
+                                                    alert('해당 참가자의 블로그 정보가 없습니다!');
+                                                }
+                                            }}
+                                        />
                                     </div>
                                 </div>
                             </div>

--- a/src/recoil/loginuser.ts
+++ b/src/recoil/loginuser.ts
@@ -12,6 +12,8 @@ const defaultValue = {
         type: 'user',
         id: '',
         name: '',
+        alias: '',
+        logo: '',
         email: '',
         level: 0,
         team: {


### PR DESCRIPTION
- **이번 PR에서 다룰 내용**
 1. 마이페이지에서 mail, instagram, github 호버 시 말풍선 위치 조정 (**완료**)
 2. 마이페이지에서 SNS 버튼 별 새탭으로열기 + 계정정보 없으면 alert 띄워주기 (**완료**)
 3. 기업 마이페이지 관련 작업 (**완료**)
   -  기업페이지 `/sponsor/:id` 제작 완료
   - 기업은 마이페이지 클릭 시 `/myCompany`로 이동 (따라서, 푸터와 헤더 수정) 
 4. 기업 API 변경으로 인한 `User` 인터페이스 수정 (**완료**)
 5. Next.js의 dynamic routing 기능을 위해 `next.config.js` 에서 프록시 설정 수정 (**완료**)
 6. 랜딩페이지 후원사목록을 이미지에서 실제 개별 클릭 가능 요소로 수정 (**완료**)
