### PR TITLE
Refactor/emily

### DIFF
--- a/src/pages/projects/list.tsx
+++ b/src/pages/projects/list.tsx
@@ -8,6 +8,7 @@ import ProjectCard from '../../components/ProjectCard';
 import { RiTeamFill } from 'react-icons/ri';
 import { useRecoilState } from 'recoil';
 import { loginRecoilState } from '../../recoil/loginuser';
+import { readJsonConfigFile } from 'typescript';
 
 interface ProjectData {
     id: string;
@@ -71,13 +72,26 @@ function ProjectList() {
     function searchUser(e: React.KeyboardEvent<HTMLInputElement>) {
         const keyword = input;
         const searchinput = document.querySelector('#searchinput') as HTMLInputElement;
-
-        if (e.key == 'Enter') {
+        if (keyword) {
+            console.log(`keyword 있음`);
+        }
+        if (e.key == 'Enter' && keyword) {
             setEnterPressed(true);
-            setSearchResult(list.filter(prj => prj._doc?.team.includes(keyword)));
-            setInput('');
+            list.map(async prj => {
+                const res = await axiosInstance.get(`/teams/${prj._doc.team}`);
+                if (res.data.data.name.includes(keyword) == true) {
+                    setSearchResult([...searchResult, prj]);
+                }
+            }),
+                setInput('');
             searchinput.blur();
-        } else return;
+        } else {
+            // 빈칸 입력 시, 전체 프로젝트 리스트 띄워줌
+            setEnterPressed(true);
+            setSearchResult([]);
+
+            return;
+        }
     }
     /* ---------------------------------------------------------------- */
 


### PR DESCRIPTION
- 문제 원인 : keyword와 prj._doc.team 을 비교해서 해당되는 것만 표시를 해주는 것이 원래 로직인데, keyword 는 "토요코인노래방"과 같은 팀 명이고, project._doc.team 은 team id 여서 하나도 매칭시키지 못하였습니다. (그래서 자꾸 검색 엔터 치면 빈 화면이 뜨는 것!!) 
- 해결책 : 사실 백엔드 API 상에서 team 명을 받아오도록 API 수정하는게 진짜 베스트인데,, 플젝 기간이 끝났기도 해서 일단 프론트 단에서 약간의 오버헤드를 감수하고 로직을 짜보았습니다!! 
 => `GET /teams/:id `를 통해 각 팀명을 가져와서 사용자가 인풋으로 넣은 keyword 와 비교하는 것입니당